### PR TITLE
Remove unnecessary CMAKE_FORTRAN_COMPILER definition from CMakeList.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,6 @@
 # check environment
 cmake_minimum_required(VERSION 3.15)
 
-# set compiler
-if (NOT DEFINED ENV{CMAKE_Fortran_COMPILER})
-  message(FATAL_ERROR "CMAKE_Fortran_COMPILER is not defined")
-endif()
-
-set(CMAKE_Fortran_COMPILER $ENV{CMAKE_Fortran_COMPILER})
-
 if(NOT DEFINED CMAKE_INSTALL_BINDIR)
   set(CMAKE_INSTALL_BINDIR exec)
 endif()


### PR DESCRIPTION
<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- The dummy definition `CMAKE_FORTRAN_COMPILER` is removed from `CMakeLists.txt`.

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [x] Hera
  - [x] Orion
  - [x] Hercules
  - [x] Derecho
  - [ ] Jet

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [x] Build test
- [ ] Test with applications
  - [x] UFS SRW App
  - [ ] RRFS Workflow
  - [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Fixes the issue(s) mentioned in #24 


